### PR TITLE
change clamp literals from int to double

### DIFF
--- a/lib/src/material_color_generator.dart
+++ b/lib/src/material_color_generator.dart
@@ -38,20 +38,20 @@ class MaterialColorGenerator {
     var accentBase = HSLColor.fromColor(Color.lerp(baseDark, baseTriad, 0.15));
     return {
       100: accentBase
-          .withSaturation((accentBase.saturation + 0.80).clamp(0, 1))
-          .withLightness((accentBase.lightness + 0.65).clamp(0, 1))
+          .withSaturation((accentBase.saturation + 0.80).clamp(0.0, 1.0))
+          .withLightness((accentBase.lightness + 0.65).clamp(0.0, 1.0))
           .toColor(),
       200: accentBase
-          .withSaturation((accentBase.saturation + 0.80).clamp(0, 1))
-          .withLightness((accentBase.lightness + 0.55).clamp(0, 1))
+          .withSaturation((accentBase.saturation + 0.80).clamp(0.0, 1.0))
+          .withLightness((accentBase.lightness + 0.55).clamp(0.0, 1.0))
           .toColor(),
       400: accentBase
-          .withSaturation((accentBase.saturation + 1.00).clamp(0, 1))
-          .withLightness((accentBase.lightness + 0.45).clamp(0, 1))
+          .withSaturation((accentBase.saturation + 1.00).clamp(0.0, 1.0))
+          .withLightness((accentBase.lightness + 0.45).clamp(0.0, 1.0))
           .toColor(),
       700: accentBase
-          .withSaturation((accentBase.saturation + 1.00).clamp(0, 1))
-          .withLightness((accentBase.lightness + 0.40).clamp(0, 1))
+          .withSaturation((accentBase.saturation + 1.00).clamp(0.0, 1.0))
+          .withLightness((accentBase.lightness + 0.40).clamp(0.0, 1.0))
           .toColor(),
     };
   }


### PR DESCRIPTION
This PR proposes a literal type change from int to double to resolve an unusual error we have been encountering on mobile platforms (web not affected). 
```
type 'int' is not a subtype of type 'double'
```
I am new to dart, but my understanding is that literals should auto-convert as of dart 2.1 (https://dart.dev/guides/language/language-tour#numbers) and we are using very recent versions, so I don't see why this would be necessary, but it does prevent the problem.